### PR TITLE
Fix the Wizardry crash.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val modVersion: String by ext.properties
@@ -76,6 +77,7 @@ tasks {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
             javaParameters.set(true)
+            languageVersion.set(KotlinVersion.KOTLIN_1_9)
             freeCompilerArgs.add("-Xjvm-default=all-compatibility")
         }
     }


### PR DESCRIPTION
Set language version to 1.9 to fix Wizardry crash. There shouldn't be any issues that occur by doing this.